### PR TITLE
Wipe salt temporary files after applying state in a VM

### DIFF
--- a/qubes.SaltLinuxVM
+++ b/qubes.SaltLinuxVM
@@ -39,4 +39,4 @@ $target_vm:
   host: $target_vm
 EOF
 export PATH="/usr/lib/qubes-vm-connector/ssh-wrapper:$PATH"
-salt-ssh "$target_vm" $salt_command
+salt-ssh -w "$target_vm" $salt_command


### PR DESCRIPTION
If both template and template-based VMs are targeted, the template-based
VM would re-use deployed salt shim from a template run. It include cache
files, especially minion id, which are not applicable to template-based
VM. Especially minion ID should be refreshed.

Fixes QubesOS/qubes-issues#4709