### PR TITLE
Switch PyYAML dependency to python3-pyyaml

### DIFF
--- a/builder.conf
+++ b/builder.conf
@@ -12,9 +12,9 @@
 # BUILDER_PLUGINS += mgmt-salt
 
 ifeq ($(PKG_MANAGER),dpkg)
- DEPENDENCIES += python-yaml
+ DEPENDENCIES += python3-yaml
 else ifeq ($(PKG_MANAGER),rpm)
- DEPENDENCIES += PyYAML
+ DEPENDENCIES += python3-pyyaml
 endif
 
 about::


### PR DESCRIPTION
This updates builder.conf so that 'make install-deps' will install the
Python 3 version of pyyaml.

Please note that I haven't tested the dpkg part of the config. The change seems trivial, but it'd be good if someone could test that.