### PR TITLE
Switch yaml-dumper to python3 and BR python3

### DIFF
--- a/rpm_spec/qubes-mgmt-salt-vm.spec.in
+++ b/rpm_spec/qubes-mgmt-salt-vm.spec.in
@@ -9,7 +9,11 @@ URL:	   http://www.qubes-os.org/
 Group:     System administration tools
 BuildArch: noarch
 Requires:  qubes-mgmt-salt
-BuildRequires: PyYAML
+%if 0%{?rhel} == 7
+BuildRequires: python%{python3_pkgversion}-PyYAML
+%else
+BuildRequires: python%{python3_pkgversion}-pyyaml
+%endif
 BuildRequires: tree
 Requires(post): /usr/bin/qubesctl
 Conflicts:  qubes-mgmt-salt-dom0

--- a/rpm_spec/qubes-mgmt-salt.spec.in
+++ b/rpm_spec/qubes-mgmt-salt.spec.in
@@ -10,7 +10,14 @@ BuildArch: noarch
 Requires:  salt >= 2015.5
 Requires:  salt-minion
 Requires:  qubes-mgmt-salt-base
+%if 0%{?fedora} == 25
 BuildRequires: PyYAML
+%endif
+%if 0%{?rhel} == 7
+BuildRequires: python%{python3_pkgversion}-PyYAML
+%else
+BuildRequires: python%{python3_pkgversion}-pyyaml
+%endif
 BuildRequires: tree
 BuildRequires: pandoc
 BuildRequires: python-setuptools
@@ -44,7 +51,14 @@ Summary:   Qubes+Salt Management base configuration for SaltStack's Salt Infrast
 Group:     System administration tools
 Requires:  salt
 Requires:  salt-minion
+%if 0%{?fedora} == 25
 BuildRequires: PyYAML
+%endif
+%if 0%{?rhel} == 7
+BuildRequires: python%{python3_pkgversion}-PyYAML
+%else
+BuildRequires: python%{python3_pkgversion}-pyyaml
+%endif
 BuildArch: noarch
 
 %description config

--- a/yaml-dumper
+++ b/yaml-dumper
@@ -1,15 +1,15 @@
-#!/usr/bin/python2 -O
+#!/usr/bin/python3 -O
 # -*- coding: utf-8 -*-`
 #
 # vim: set ts=4 sw=4 sts=4 et :
-'''
+"""
 :maintainer:    Jason Mehring <nrgaway@gmail.com>
 :maturity:      new
 :depends:       none
 :platform:      all
 
 Dump a YAML configuration file to key = value pairs
-'''
+"""
 
 import argparse
 import collections


### PR DESCRIPTION
PyYAML(python2) remains needed only for qubessalt package for dom0 fc25