### PR TITLE
Modify qubesctl to use the new policy format

### DIFF
--- a/rpm_spec/qubes-mgmt-salt.spec.in
+++ b/rpm_spec/qubes-mgmt-salt.spec.in
@@ -73,6 +73,8 @@ Summary:    Management tools integrating dom0 and VM management
 Group:     System administration tools
 BuildArch: noarch
 Requires:  qubes-mgmt-salt
+# doesn't work with old Admin API policy layout
+Conflicts: qubes-core-dom0 < 4.1.12
 
 %description admin-tools
 Tools to integrate dom0 and VM management into a single qubesctl tool.


### PR DESCRIPTION
Use a single /etc/qubes/policy.d/50-qubesctl-salt.policy policy file for
dynamic rules, instead of legacy per-service files in
/etc/qubes-rpc/policy. This way it's easier to manage the policies by
salt (add a comment it's an automatically generated file), while it's
still possible for the admin to enforce other rules (in other files).

QubesOS/qubes-issues#4370