### PR TITLE
removed templates apps and standalones from the muturally exclusive group

### DIFF
--- a/qubesctl
+++ b/qubesctl
@@ -29,15 +29,15 @@ def main(args=None):  # pylint: disable=missing-docstring
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--targets', action='store',
                        help='Comma separated list of VMs to target')
-    group.add_argument('--templates', action='store_true',
-                       help='Target all TemplatesVMs')
-    group.add_argument('--standalones', action='store_true',
-                       help='Target all StandaloneVMs')
-    group.add_argument('--app', action='store_true',
-                       help='Target all AppVMs')
     group.add_argument('--all', action='store_true',
                        help='Target all non-disposable VMs (TemplateVMs and '
                             'AppVMs)')
+    parser.add_argument('--templates', action='store_true',
+                       help='Target all TemplatesVMs')
+    parser.add_argument('--standalones', action='store_true',
+                       help='Target all StandaloneVMs')
+    parser.add_argument('--app', action='store_true',
+                       help='Target all AppVMs')
     parser.add_argument('command',
                         help='Salt command to execute (for example: '
                              'state.highstate)',


### PR DESCRIPTION
Fixes https://github.com/QubesOS/qubes-issues/issues/6514
No de-duping was needed (at least in its present state), as all and target override all other target options, and app/template/standalone cannot collide.

Downside of this PR is the user might be confused if they try to do `qubesctl --app --target sys-net` and are surprised when only sys-net is targeted.