### PR TITLE
Apply workaround for highstate rendering failure

### DIFF
--- a/qubes.SaltLinuxVM
+++ b/qubes.SaltLinuxVM
@@ -42,4 +42,8 @@ $target_vm:
   host: $target_vm
 EOF
 export PATH="/usr/lib/qubes-vm-connector/ssh-wrapper:$PATH"
+
+# workaround for saltstack/salt#60003
+sed -i -e 's/if cached_client is None:/if cached_client is None or cached_client.opts["cachedir"] != self.opts["cachedir"]:/' \
+        /usr/lib/python3*/site-packages/salt/utils/jinja.py
 salt-ssh -w "$target_vm" $salt_command


### PR DESCRIPTION
Unbreak salt using dirty hack, until upstream applies the proper fix.
This is executed in a DispVM, so the change is not persistent - when
upstream fix will be there, it's enough to simply drop this line.

Workaround for saltstack/salt#60003

Fixes QubesOS/qubes-issues#6580