### PR TITLE
Place VMRootShell policy file before loading legacy policy

### DIFF
--- a/qubessalt/__init__.py
+++ b/qubessalt/__init__.py
@@ -287,7 +287,7 @@ class ManageVMRunner(object):
 
 def qrexec_policy(src, dst, allow):
     while True:
-        path = '/etc/qubes/policy.d/50-qubesctl-salt.policy'
+        path = '/etc/qubes/policy.d/30-qubesctl-salt.policy'
         # Mode is a bit tricky here. We want to *atomically*:
         # - open an existing file for reading (do not truncate it)
         # - if the file does not exist - create it


### PR DESCRIPTION
Legacy policy leftover could contain `@anyvm @anyvm deny` rule (which is
expected in R4.0, but not appropriate in R4.1 anymore). To avoid
conflict, place dynamic rule earlier - at order "30".
If user wants, it's still possible to override this by earlier policy
files.

Fixes QubesOS/qubes-issues#7486
Fixes QubesOS/qubes-issues#7122