### PR TITLE
Fix passing quoted arguments to salt-ssh

### DIFF
--- a/qubes.SaltLinuxVM
+++ b/qubes.SaltLinuxVM
@@ -51,4 +51,7 @@ $target_vm:
 EOF
 export PATH="/usr/lib/qubes-vm-connector/ssh-wrapper:$PATH"
 
-salt-ssh -w "$target_vm" $salt_command
+# Ensure the arguments for salt-ssh are tokenized correctly.
+# Without this parsing, the salt_command is just split on whitespace.
+# E.g.: test.echo 'foo bar' -> ['test.echo', "'foo", "bar'"]
+eval "salt-ssh -w $target_vm $salt_command"


### PR DESCRIPTION
Fixes: https://github.com/QubesOS/qubes-issues/issues/6106 (which was closed, but is still relevant on 4.2rc4)

For a detailed reproduction, see my post in the linked issue. I have verified this working with a patched template for `default-mgmt-dvm`~~, not sure if there are better ways without rewriting the service in Python~~.

Previously, any command that contained quoted arguments would not have been received correctly by `salt-ssh`. Examples for salt_command -> sys.argv:

`test.echo 'hi there foobar'` -> `['test.echo', "'hi", 'there', "foobar'"]`
`state.sls repro 'pillar={"foo":"bar"}'` -> `['state.sls', 'repro', "'pillar={"foo":"bar"}'"]`

This is caused by bash just splitting the arguments on whitespace instead of parsing them as shell args when a variable is expanded.

~~This solution makes use of xargs to properly parse the input string into tokens, prints them delimited by a null byte and reads each item into a bash array. The null byte delimiter ensures other characters do not cause an unintentional split. This array is then expanded as arguments to salt-ssh.~~
Just eval them to fix it. Input comes from a trusted source and `salt_command` is escaped, VM names do not contain chars that might cause surprising behavior.

Hope I have done everything correctly regarding contribution guidelines, not sure if I should or how I can submit tests. Thanks for all your hard work on Qubes OS, really appreciate it!