### PR TITLE
Improve `has_config` check behavior

### DIFF
--- a/doc/qubesctl.rst
+++ b/doc/qubesctl.rst
@@ -21,7 +21,7 @@ OPTIONS
 --show-output
 Show output of management commands
 
---force-colour
+--force-color
 Show output in colour, and allow control characters from qubes.
 This option is UNSAFE
 

--- a/doc/qubesctl.rst
+++ b/doc/qubesctl.rst
@@ -43,6 +43,8 @@ Target all non disposable VMs, (Templates and AppVMs)
 --max-concurrency <number>
 Maximum number of VMs configured simultaneously. Default: 4
 
+--skip-top-check
+Do not skip targeted qubes during a highstate if it appears they are not targeted by any state.
 
 AUTHORS
 =======

--- a/qubesctl
+++ b/qubesctl
@@ -26,6 +26,9 @@ def main(args=None):  # pylint: disable=missing-docstring
                         help='Maximum number of VMs configured simultaneously '
                              '(default: %(default)d)',
                         type=int, default=4)
+    parser.add_argument('--skip-top-check', action='store_true',
+                        help='Do not skip targeted qubes during a highstate if '
+                             'it appears they are not targeted by any state')
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--targets', action='store',
                        help='Comma separated list of VMs to target')
@@ -85,7 +88,8 @@ def main(args=None):  # pylint: disable=missing-docstring
     runner = qubessalt.ManageVMRunner(app, vms_to_go, args.command,
                                       show_output=args.show_output,
                                       force_color=args.force_color,
-                                      max_concurrency=args.max_concurrency)
+                                      max_concurrency=args.max_concurrency,
+                                      skip_top_check=args.skip_top_check)
     exit_code = runner.run()
     # then non-templates (AppVMs)
     vms_to_go = [vm for vm in targets
@@ -93,7 +97,8 @@ def main(args=None):  # pylint: disable=missing-docstring
     runner = qubessalt.ManageVMRunner(app, vms_to_go, args.command,
                                       show_output=args.show_output,
                                       force_color=args.force_color,
-                                      max_concurrency=args.max_concurrency)
+                                      max_concurrency=args.max_concurrency,
+                                      skip_top_check=args.skip_top_check)
     return max(exit_code, runner.run())
 
 

--- a/qubessalt/__init__.py
+++ b/qubessalt/__init__.py
@@ -249,11 +249,12 @@ def has_config(vm):
 
 
 def run_one(vmname, command, show_output, force_color, skip_top_check):
-    try:
-        if not skip_top_check and 'state.highstate' in command and not has_config(vmname):
-            return vmname, 0, "SKIP (nothing to do)"
-    except Exception as err:  # pylint: disable=broad-except
-        return vmname, 1, f"ERROR (exception {err})"
+    if not skip_top_check and 'state.highstate' in command:
+        try:
+            if not has_config(vmname):
+                return vmname, 0, "SKIP (nothing to do)"
+        except Exception as err:  # pylint: disable=broad-except
+            return vmname, 1, f"ERROR (exception {err})"
     app = qubesadmin.Qubes()
     try:
         vm = app.domains[vmname]


### PR DESCRIPTION
* Moves `has_config` call into `run_one`, which makes it run in parallel. This also works during a local highstate since `concurrent=True` is passed, which makes Salt not fail when another state job is running. In my testing, for an invocation consisting only of 8 skips, this reduced total runtime from ~8.5s to ~5s. I checked whether loading the config repeatedly vs (deep)copying and passing it would make a difference, it did not.
* Introduces `--skip-top-check` option to skip this check completely - it is not reliable if states are targeted by grains. In case a state run did not contain any states, `salt-ssh` will exit with 20 and `qubesctl` will report an error.
* Fix `--force-color` description, which was not in sync with the code.

Fixes: https://github.com/QubesOS/qubes-issues/issues/6144