### PR TITLE
Ensure custom modules can run on salt-ssh master

### DIFF
--- a/doc/qubesctl.rst
+++ b/doc/qubesctl.rst
@@ -46,6 +46,10 @@ Maximum number of VMs configured simultaneously. Default: 4
 --skip-top-check
 Do not skip targeted qubes during a highstate if it appears they are not targeted by any state.
 
+--sync-extmods
+Sync all custom extension module types before running the command to ensure they will be available on the salt-ssh master.
+This is only required (once after each modification) for specific module types such as outputters, tops and wrappers.
+
 AUTHORS
 =======
 | unman <unman@thirdeyesecurity.org> 

--- a/qubes.SaltLinuxVM
+++ b/qubes.SaltLinuxVM
@@ -43,6 +43,7 @@ if [ -f /srv/master ]; then
   mv /srv/master /etc/salt/
 fi
 if [ -d /srv/_extmods ]; then
+    rm -rf /var/cache/salt/master/extmods
     mkdir -p /var/cache/salt/master
     mv /srv/_extmods /var/cache/salt/master/extmods
 fi

--- a/qubes.SaltLinuxVM
+++ b/qubes.SaltLinuxVM
@@ -42,6 +42,10 @@ mkdir -p /etc/salt
 if [ -f /srv/master ]; then
   mv /srv/master /etc/salt/
 fi
+if [ -d /srv/_extmods ]; then
+    mkdir -p /var/cache/salt/master
+    mv /srv/_extmods /var/cache/salt/master/extmods
+fi
 # do not fail if 'salt' user doesn't exit, we run as root
 echo 'verify_env: False' >> /etc/salt/master
 (cd /srv/salt; find _tops -type f -o -type l| sed -e 's/^/- /' > tops.yaml)

--- a/qubesctl
+++ b/qubesctl
@@ -11,6 +11,8 @@ import subprocess
 import qubessalt
 import qubesadmin
 import qubesadmin.vm
+from salt.utils import context as ctx
+from salt.runners import saltutil
 
 
 def main(args=None):  # pylint: disable=missing-docstring
@@ -29,6 +31,10 @@ def main(args=None):  # pylint: disable=missing-docstring
     parser.add_argument('--skip-top-check', action='store_true',
                         help='Do not skip targeted qubes during a highstate if '
                              'it appears they are not targeted by any state')
+    parser.add_argument('--sync-extmods', action='store_true',
+                        help='Sync *all* custom extension module types before '
+                             'running the command to ensure they will be '
+                             'available on the salt-ssh master')
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--targets', action='store',
                        help='Comma separated list of VMs to target')
@@ -46,6 +52,15 @@ def main(args=None):  # pylint: disable=missing-docstring
                              'state.highstate)',
                         nargs=argparse.REMAINDER)
     args = parser.parse_args(args)
+
+    if args.sync_extmods:
+        opts = qubessalt.load_opts()
+        # Doing it this way because the RunnerClient requires actual
+        # master opts, which we could load, but we want this to end
+        # up in the minion extension_modules dir. Don't assume defaults,
+        # don't load twice.
+        with ctx.func_globals_inject(saltutil.sync_all, __opts__=opts):
+            saltutil.sync_all()
 
     if not args.skip_dom0:
         try:


### PR DESCRIPTION
Custom modules are currently not synced to the master cache dir of the mgmt DVM before invoking salt-ssh, which means some module types do not work.

This is a proposal to fix the behavior by

1. including the dom0 minion's synced modules in the package sent to the mgmt DVM
2. providing an inbuilt way to also include master-only module types in there.

Fixes https://github.com/QubesOS/qubes-issues/issues/8634 (see there for notes on alternatives to `--sync-extmods`).