### PR TITLE
Support 'state.apply' in addition to 'state.highstate'

### DIFF
--- a/qubessalt/__init__.py
+++ b/qubessalt/__init__.py
@@ -254,7 +254,14 @@ def has_config(vm):
 
 
 def run_one(vmname, command, show_output, force_color, skip_top_check):
-    if not skip_top_check and 'state.highstate' in command:
+    uses_top = False
+    if 'state.highstate' in command:
+        uses_top = True
+    # there could be some options after, but lean on the safe side - better
+    # just disable optimization than skip some state to apply
+    if command[-1] == 'state.apply':
+        uses_top = True
+    if not skip_top_check and uses_top:
         try:
             if not has_config(vmname):
                 return vmname, 0, "SKIP (nothing to do)"


### PR DESCRIPTION
The former is more logical name and is preferred upstream. Handle it in
the qubesctl command, to apply states only to VMs where there is
anything to apply.

It's a bit more complicated, becase (contrary to state.highstate) it can
be also used to apply a single state not using top file. So, apply
optimization only when 'state.apply' is the last word. This will
correctly handle simple cases like `qubesctl --all state.apply`, but if
one use some extra arguments like `qubesctl --all state.apply test=True`
it will disable the optimization and will call it on all the VMs (also
where there is nothing to apply). Since full command parsing will be
complicated (and keeping it in sync with salt will be fragile), opt on
the safe side - better have possibly suboptimal performance but correct
result, instead of risking incorrect results.

Related to QubesOS/qubes-doc#1266