### PR TITLE
Fix handling empty base top

### DIFF
--- a/srv/salt/top.sls
+++ b/srv/salt/top.sls
@@ -22,15 +22,18 @@
 
 {%- set default = {'base': {'*': ['topd']}}|yaml %}
 
-{% load_yaml as tops %}
-{% include "tops.yaml" ignore missing %}
-{% endload %}
 
 # If static list of enabled tops is present in "tops.yaml", use it without
 # using salt.top module (it may be not available while using salt-ssh)
-{%- if tops -%}
-{%- from "top.jinja" import merge_tops -%}
-{%- set top = merge_tops(tops) -%}
+{%- if "/srv/salt/tops.yaml"|is_text_file -%}
+  {%- load_yaml as tops %}
+    {%- include "tops.yaml" %}
+  {%- endload %}
+  {%- if not tops %}
+    {%- set tops = [] %}
+  {%- endif %}
+  {%- from "top.jinja" import merge_tops -%}
+  {%- set top = merge_tops(tops) -%}
 # otherwise, try to use salt.top module if present
 {%- elif salt.top is defined %}
   {%- set top = salt.top.get_top('salt://_tops', opts, saltenv=None)|yaml %}


### PR DESCRIPTION
When the base top is empty, the "if tops" condition fails even in the
DispVM where tops.yaml file exists. This leads to trying salt.top in
a VM, which isn't installed there.

Fix this by using `is_text_file` test instead of checking for emptiness.
But then, merge_tops() can't handle empty string - it expects a proper
list of top files. To fix this, set tops to empty list if it's an empty
string.

Fixes QubesOS/qubes-issues#8491