### PR TITLE
SALT exit 20: replace `ERROR` with `NOTHING TO DO`

### DIFF
--- a/qubessalt/__init__.py
+++ b/qubessalt/__init__.py
@@ -221,9 +221,13 @@ fi
                             self.mgmt_template),
                         self.mgmt_template)
             else:
-                return_data = "OK" if p.returncode == 0 else \
-                    "ERROR (exit code {}, details in {})".format(
-                        p.returncode,     self.log_path)
+                if p.returncode == 0:
+                    return_data = "OK"
+                elif p.returncode == 20:
+                    return_data = "NOTHING TO DO"
+                else:
+                    return_data = "ERROR (exit code {}, details in {})".format(
+                        p.returncode, self.log_path)
             if self.vm.is_running() and not initially_running:
                 self.vm.shutdown()
                 # FIXME: convert to self.vm.shutdown(wait=True) in core3


### PR DESCRIPTION
When SALT exits with code 20, print `NOTHING TO DO` instead of `ERROR`.

Better error messages will [aid the move to make SALT more accessible](https://github.com/QubesOS/qubes-issues/issues/8218) and this particular one is already causing some confusion outside of SALT users (just search Qubes error 20).

Example of how things look prior to this patch:

```console
Summary for local
------------
Succeeded: 2
Failed:    0
------------
Total states run:     2
Total run time:   8.368 ms
debian-12-xfce: ERROR (exit code 20, details in /var/log/qubes/mgmt-debian-12-xfce.log)
```

`/var/log/qubes/mgmt-debian-12-xfce.log`:
```log
calling 'state.highstate'...
output: debian-12-xfce:
output:
output: Summary for debian-12-xfce
output: -----------
output: Succeeded: 0
output: Failed:   0
output: -----------
output: Total states run:    0
output: Total run time:  0.000 ms
exit code: 20
```

And how it looks with this patch:

```console
Summary for local
------------
Succeeded: 2
Failed:    0
------------
Total states run:     2
Total run time:   9.013 ms
debian-12-xfce: NOTHING TO DO
```

(same log)

-----

We may also want to document that "NOTHING TO DO" differs from "SKIP" in that the VM has been targeted (and booted) only to do nothing (which is a waste unless the VM needed to be booted to check something).