### PR TITLE
Include forked certifi package that handles both Debian and Fedora

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,16 +1,16 @@
 include:
   - project: 'QubesOS/qubes-continuous-integration'
-    file: '/r4.1/gitlab-base.yml'
-  - project: 'QubesOS/qubes-continuous-integration'
-    file: '/r4.1/gitlab-dom0.yml'
-  - project: 'QubesOS/qubes-continuous-integration'
-    file: '/r4.1/gitlab-vm.yml'
-  - project: 'QubesOS/qubes-continuous-integration'
     file: '/r4.2/gitlab-base.yml'
   - project: 'QubesOS/qubes-continuous-integration'
     file: '/r4.2/gitlab-host.yml'
   - project: 'QubesOS/qubes-continuous-integration'
     file: '/r4.2/gitlab-vm.yml'
+  - project: 'QubesOS/qubes-continuous-integration'
+    file: '/r4.3/gitlab-base.yml'
+  - project: 'QubesOS/qubes-continuous-integration'
+    file: '/r4.3/gitlab-host.yml'
+  - project: 'QubesOS/qubes-continuous-integration'
+    file: '/r4.3/gitlab-vm.yml'
 
 variables:
   TRAVIS_INSTALL_EXCLUDE: "qubes-mgmt-salt-dom0 qubes-mgmt-salt-dom0-formulas"

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ install-vm:
 	install ssh-wrapper $(DESTDIR)/usr/lib/qubes-vm-connector/ssh-wrapper/ssh
 	ln -s ssh $(DESTDIR)/usr/lib/qubes-vm-connector/ssh-wrapper/scp
 	ln -s /bin/true $(DESTDIR)/usr/lib/qubes-vm-connector/ssh-wrapper/ssh-keygen
+	install -d $(DESTDIR)/usr/lib/qubes-vm-connector/python-override
+	cp -r python-override/certifi \
+		$(DESTDIR)/usr/lib/qubes-vm-connector/python-override/
 	install -d $(DESTDIR)/etc/qubes-rpc
 	install qubes.SaltLinuxVM $(DESTDIR)/etc/qubes-rpc
 

--- a/python-override/certifi/__init__.py
+++ b/python-override/certifi/__init__.py
@@ -1,0 +1,4 @@
+from .core import contents, where
+
+__all__ = ["contents", "where"]
+__version__ = "2023.05.07"

--- a/python-override/certifi/__main__.py
+++ b/python-override/certifi/__main__.py
@@ -1,0 +1,12 @@
+import argparse
+
+from certifi import contents, where
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-c", "--contents", action="store_true")
+args = parser.parse_args()
+
+if args.contents:
+    print(contents())
+else:
+    print(where())

--- a/python-override/certifi/core.py
+++ b/python-override/certifi/core.py
@@ -1,0 +1,21 @@
+"""
+certifi.py
+~~~~~~~~~~
+
+This module returns the installation location of cacert.pem or its contents.
+"""
+
+import os.path
+
+DEBIAN_CA_CERTS_PATH = '/etc/ssl/certs/ca-certificates.crt'
+
+# The RPM-packaged certifi always uses the system certificates
+def where() -> str:
+    if os.path.exists(DEBIAN_CA_CERTS_PATH):
+        return DEBIAN_CA_CERTS_PATH
+    return '/etc/pki/tls/certs/ca-bundle.crt'
+
+def contents() -> str:
+    with open(where(), encoding='utf=8') as data:
+        return data.read()
+

--- a/qubes.SaltLinuxVM
+++ b/qubes.SaltLinuxVM
@@ -55,6 +55,7 @@ $target_vm:
   host: $target_vm
 EOF
 export PATH="/usr/lib/qubes-vm-connector/ssh-wrapper:$PATH"
+export PYTHONPATH="/usr/lib/qubes-vm-connector/python-override:$PYTHONPATH"
 
 # Ensure the arguments for salt-ssh are tokenized correctly.
 # Without this parsing, the salt_command is just split on whitespace.

--- a/rpm_spec/qubes-mgmt-salt-vm.spec.in
+++ b/rpm_spec/qubes-mgmt-salt-vm.spec.in
@@ -45,6 +45,7 @@ make install-vm DESTDIR=%{buildroot}
 %defattr(-,root,root)
 /etc/qubes-rpc/qubes.SaltLinuxVM
 /usr/lib/qubes-vm-connector/ssh-wrapper
+/usr/lib/qubes-vm-connector/python-override
 
 %changelog
 @CHANGELOG@


### PR DESCRIPTION
Both Fedora and Debian have patched certifi package to use system CA
bundle instead of one managed by certifi internally. Those CA bundle
paths are different between distributions.
When Fedora mgmt dispvm is used to manage Debian, the CA bundle path
doesn't match, resulting in a crash when importing 'requests' module
(which itself uses 'certifi' to load CA bundle).

Include modified 'certifi' package that has paths for both Debian and
Fedora, and make salt-ssh use it via PYTHONPATH variable.

Fixes QubesOS/qubes-issues#10262