### PR TITLE
qubesctl: rename `--app` to `--apps` for consistency

### DIFF
--- a/doc/qubesctl.rst
+++ b/doc/qubesctl.rst
@@ -34,7 +34,7 @@ Comma separated list of qubes to target
 --templates
 Target all templates
 
---app
+--apps
 Target all AppVMs
 
 --all

--- a/qubesctl
+++ b/qubesctl
@@ -45,7 +45,7 @@ def main(args=None):  # pylint: disable=missing-docstring
                        help='Target all TemplatesVMs')
     parser.add_argument('--standalones', action='store_true',
                        help='Target all StandaloneVMs')
-    parser.add_argument('--app', action='store_true',
+    parser.add_argument('--apps', '--app', action='store_true',
                        help='Target all AppVMs')
     parser.add_argument('command',
                         help='Salt command to execute (for example: '
@@ -80,7 +80,7 @@ def main(args=None):  # pylint: disable=missing-docstring
     if args.standalones:
         targets += [vm for vm in app.domains.values()
                     if vm.klass == 'StandaloneVM']
-    if args.app:
+    if args.apps:
         targets += [vm for vm in app.domains.values()
                     if vm.klass == 'AppVM']
     if args.all:


### PR DESCRIPTION
consistent with the existing plural flags like `--templates` and `--standalones`

Keep --app as a backward-compatible alias so existing scripts and documentation referencing the old flag continue to work.

Update the man page to reflect the new primary flag name.

closes: https://github.com/QubesOS/qubes-issues/issues/6403