### PR TITLE
Fix reporting exceptions

### DIFF
--- a/qubessalt/__init__.py
+++ b/qubessalt/__init__.py
@@ -202,7 +202,7 @@ fi
 
             for line in stdout_lines:
                 self.log.info('output: %s', line)
-            if stdout_lines[0].count(self.vm.name + ':') == 1:
+            if stdout_lines and stdout_lines[0].count(self.vm.name + ':') == 1:
                 stdout_lines = stdout_lines[1:]
             self.log.info('exit code: %d', p.returncode)
             exit_code = p.returncode


### PR DESCRIPTION
When running state hits exception, there is no qube name prefix in the
output, just the exception message (like "missing
qubes-mgmt-salt-vm-connector"). Make error handling prepared for such
case too.
